### PR TITLE
docs: Document missing environment variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,23 @@ Files are split into overlapping chunks for granular search:
 
 All settings can be overridden via environment:
 
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VGREP_HOST` | `127.0.0.1` | Server bind address |
+| `VGREP_PORT` | `7777` | Server port |
+| `VGREP_MAX_RESULTS` | `10` | Default number of search results |
+| `VGREP_CONTENT` | `false` | Show code snippets in results |
+| `VGREP_CHUNK_SIZE` | `512` | Characters per chunk when indexing |
+| `VGREP_CHUNK_OVERLAP` | `64` | Overlap between chunks in characters |
+| `VGREP_MAX_FILE_SIZE` | `524288` | Maximum file size to index in bytes (512KB) |
+| `VGREP_WATCH_DEBOUNCE` | `500` | File watcher debounce delay in milliseconds |
+
+Example usage:
+
 ```bash
-VGREP_HOST=0.0.0.0      # Bind to all interfaces
-VGREP_PORT=8080         # Custom port
-VGREP_MAX_RESULTS=20    # More results
-VGREP_CONTENT=true      # Always show snippets
+VGREP_HOST=0.0.0.0 VGREP_PORT=8080 vgrep serve  # Custom host/port
+VGREP_MAX_RESULTS=20 vgrep search "query"       # More results
+VGREP_CHUNK_SIZE=1024 vgrep index               # Larger chunks
 ```
 
 ---


### PR DESCRIPTION
## Summary

This PR adds documentation for environment variables that were implemented in the codebase but were missing from the README.

## Problem

The README documented only 4 environment variables (VGREP_HOST, VGREP_PORT, VGREP_MAX_RESULTS, VGREP_CONTENT) while the source code in src/config.rs actually supports additional environment variables for configuration overrides. Users had no way of knowing about these options without reading the source code.

## Solution

Updated the Environment Variables section in the README to include all supported environment variables:

- **VGREP_CHUNK_SIZE**: Characters per chunk when indexing (default: 512)
- **VGREP_CHUNK_OVERLAP**: Overlap between chunks in characters (default: 64)
- **VGREP_MAX_FILE_SIZE**: Maximum file size to index in bytes (default: 524288)
- **VGREP_WATCH_DEBOUNCE**: File watcher debounce delay in milliseconds (default: 500)

The section has also been reformatted as a table for better readability and consistency with other sections of the documentation, along with practical usage examples.

## Testing

Verified that all documented environment variables match the implementation in src/config.rs and src/cli/commands.rs.

## Related Issue

Fixes PlatformNetwork/bounty-challenge#35