### PR TITLE
Fix: Add proper error handling for db_path in server API

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -143,7 +143,20 @@ async fn health() -> impl IntoResponse {
 }
 
 async fn status(State(state): State<SharedState>) -> impl IntoResponse {
-    let db = match Database::new(&state.config.db_path().unwrap_or_default()) {
+    let db_path = match state.config.db_path() {
+        Ok(path) => path,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("Failed to resolve database path: {}", e)
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let db = match Database::new(&db_path) {
         Ok(db) => db,
         Err(e) => {
             return (
@@ -228,7 +241,20 @@ async fn search(
     };
 
     // Search in database
-    let db = match Database::new(&state.config.db_path().unwrap_or_default()) {
+    let db_path = match state.config.db_path() {
+        Ok(path) => path,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("Failed to resolve database path: {}", e)
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let db = match Database::new(&db_path) {
         Ok(db) => db,
         Err(e) => {
             return (


### PR DESCRIPTION
## Summary

This PR adds explicit error handling for database path resolution failures in the server API endpoints.

## Problem

The status() and search() endpoints in src/server/api.rs were using state.config.db_path().unwrap_or_default() to obtain the database path. When db_path() fails (which returns Result<PathBuf>), unwrap_or_default() silently converts the error into an empty PathBuf.

This is problematic because:
- SQLite may interpret an empty path as a request for an in-memory database
- User data could be lost without any indication of failure
- Search operations may return empty results with no error message
- The actual cause of the failure is completely hidden from the user

## Solution

Replaced unwrap_or_default() with explicit error handling using match expressions. When db_path() fails, the API now:
- Returns HTTP 500 Internal Server Error status code
- Provides a descriptive error message including the underlying failure reason
- Prevents any attempt to open a database with an invalid path

The changes affect:
- Line 146: status() endpoint
- Line 231: search() endpoint

## Testing

The fix has been verified by code review. The changes ensure proper error propagation follows the same pattern used elsewhere in the codebase for other error conditions.

## Related Issue

Fixes PlatformNetwork/bounty-challenge#36