### PR TITLE
 Fix: Disable reranker by default as it is not yet implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Files are split into overlapping chunks for granular search:
 | `chunk_size` | `512` | Characters per chunk |
 | `chunk_overlap` | `64` | Overlap between chunks |
 | `n_threads` | `0` | CPU threads (0 = auto) |
-| `use_reranker` | `true` | Enable result reranking |
+| `use_reranker` | `false` | Enable result reranking (not yet implemented) |
 
 ### Environment Variables
 
@@ -483,7 +483,9 @@ vgrep/
 | Model | Size | Purpose |
 |-------|------|---------|
 | Qwen3-Embedding-0.6B-Q8_0 | ~600 MB | Text → Vector embeddings |
-| Qwen3-Reranker-0.6B-Q4_K_M | ~400 MB | Result reranking (optional) |
+| Qwen3-Reranker-0.6B-Q4_K_M | ~400 MB | Result reranking (not yet implemented) |
+
+The embedding model is downloaded by default with `vgrep models download`. The reranker model is reserved for future use and can be downloaded separately with `vgrep models download --reranker-only`.
 
 Models are downloaded to `~/.cache/huggingface/` and cached automatically.
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -872,7 +872,9 @@ fn run_models(action: ModelsAction, config: &mut Config) -> Result<()> {
                 config.set_embedding_model(embedding_path.to_string_lossy().to_string())?;
             }
 
-            if !embedding_only {
+            // Reranker is not yet implemented (requires separate backend)
+            // Only download if explicitly requested with --reranker-only
+            if reranker_only {
                 println!();
                 println!("  {}Downloading reranker model...", ui::DOWNLOAD);
                 println!(
@@ -882,6 +884,11 @@ fn run_models(action: ModelsAction, config: &mut Config) -> Result<()> {
                 println!(
                     "    {} huggingface.co/sinjab/Qwen3-Reranker-0.6B-Q4_K_M-GGUF",
                     style("From:").dim()
+                );
+                println!();
+                println!(
+                    "    {} Reranker is not yet implemented, downloading for future use",
+                    style("Note:").yellow()
                 );
                 println!();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,7 +160,7 @@ fn default_context_size() -> usize {
 }
 
 fn default_use_reranker() -> bool {
-    true
+    false
 }
 
 impl Default for Config {


### PR DESCRIPTION
## Summary

This fix addresses the issue where the reranker feature is documented and configured as enabled by default, but is never actually used in the codebase.

## Problem

The reranker functionality was advertised in documentation and enabled by default in configuration, causing users to download a ~400MB reranker model (Qwen3-Reranker-0.6B-Q4_K_M.gguf). However, the actual implementation in `src/core/search.rs` explicitly disables the reranker with a comment stating it requires a separate backend that conflicts with the embedding engine.

This results in:
- Wasted bandwidth downloading an unused 400MB model
- Wasted disk space storing the unused model
- User confusion when the documented feature has no effect

## Solution

1. Changed `use_reranker` default from `true` to `false` in `src/config.rs`
2. Modified `vgrep models download` command to only download the embedding model by default
3. The reranker model can still be downloaded explicitly using `--reranker-only` flag for future use
4. Updated README.md to clearly indicate that reranker is not yet implemented

## Testing

- Verified that default configuration no longer enables reranker
- Verified that `vgrep models download` only downloads the embedding model
- Verified that `vgrep models download --reranker-only` still works for those who want the model

## Related Issue

Fixes PlatformNetwork/bounty-challenge#24
