### PR TITLE
Fix: Correct chunk overlap calculation to use actual character count

### DIFF
--- a/src/core/indexer.rs
+++ b/src/core/indexer.rs
@@ -352,7 +352,19 @@ impl Indexer {
                 });
 
                 let overlap_start = if line_idx > 0 {
-                    line_idx.saturating_sub(self.chunk_overlap / 40)
+                    // Calculate how many lines we need to include to achieve
+                    // the desired character overlap
+                    let mut overlap_chars = 0;
+                    let mut overlap_lines = 0;
+                    for i in (0..line_idx).rev() {
+                        let line_char_len = lines[i].len() + 1; // +1 for newline
+                        if overlap_chars + line_char_len > self.chunk_overlap {
+                            break;
+                        }
+                        overlap_chars += line_char_len;
+                        overlap_lines += 1;
+                    }
+                    line_idx.saturating_sub(overlap_lines.max(1))
                 } else {
                     0
                 };
@@ -728,7 +740,19 @@ impl ServerIndexer {
                 });
 
                 let overlap_start = if line_idx > 0 {
-                    line_idx.saturating_sub(self.chunk_overlap / 40)
+                    // Calculate how many lines we need to include to achieve
+                    // the desired character overlap
+                    let mut overlap_chars = 0;
+                    let mut overlap_lines = 0;
+                    for i in (0..line_idx).rev() {
+                        let line_char_len = lines[i].len() + 1; // +1 for newline
+                        if overlap_chars + line_char_len > self.chunk_overlap {
+                            break;
+                        }
+                        overlap_chars += line_char_len;
+                        overlap_lines += 1;
+                    }
+                    line_idx.saturating_sub(overlap_lines.max(1))
                 } else {
                     0
                 };

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -416,7 +416,19 @@ impl FileWatcher {
                 });
 
                 let overlap_start = if line_idx > 0 {
-                    line_idx.saturating_sub(self.config.chunk_overlap / 40)
+                    // Calculate how many lines we need to include to achieve
+                    // the desired character overlap
+                    let mut overlap_chars = 0;
+                    let mut overlap_lines = 0;
+                    for i in (0..line_idx).rev() {
+                        let line_char_len = lines[i].len() + 1; // +1 for newline
+                        if overlap_chars + line_char_len > self.config.chunk_overlap {
+                            break;
+                        }
+                        overlap_chars += line_char_len;
+                        overlap_lines += 1;
+                    }
+                    line_idx.saturating_sub(overlap_lines.max(1))
                 } else {
                     0
                 };


### PR DESCRIPTION
## Summary

This change corrects the chunk overlap calculation to properly count characters instead of using an arbitrary division by 40.

## Problem

The original implementation calculated overlap by dividing the configured chunk_overlap value by 40, under the assumption that lines average 40 characters. This approach was flawed:

- With the default chunk_overlap=64, the actual overlap was only 1 line (64/40=1), regardless of actual line lengths
- This did not match the documented behavior where chunk_overlap specifies the overlap in characters
- Files with very short or very long lines would have inconsistent overlap behavior

## Solution

The fix implements proper character-based overlap calculation by:

1. Iterating backwards through preceding lines
2. Accumulating character counts until the target overlap is reached
3. Using the actual number of lines needed to achieve the desired character overlap

This ensures the overlap accurately reflects the configured character count, improving indexing consistency across files with varying line lengths.

## Testing

The fix maintains the same function signature and behavior contract. The changes affect:
- src/core/indexer.rs: Indexer.chunk_content() method
- src/core/indexer.rs: ServerIndexer.chunk_content() method
- src/watcher.rs: FileWatcher.chunk_content() method

## Related Issue

Fixes PlatformNetwork/bounty-challenge#22