### PR TITLE
Fix: Handle empty database path when current directory is invalid

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -143,7 +143,20 @@ async fn health() -> impl IntoResponse {
 }
 
 async fn status(State(state): State<SharedState>) -> impl IntoResponse {
-    let db = match Database::new(&state.config.db_path().unwrap_or_default()) {
+    let db_path = match state.config.db_path() {
+        Ok(path) => path,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("Failed to determine database path: {}", e)
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let db = match Database::new(&db_path) {
         Ok(db) => db,
         Err(e) => {
             return (
@@ -228,7 +241,20 @@ async fn search(
     };
 
     // Search in database
-    let db = match Database::new(&state.config.db_path().unwrap_or_default()) {
+    let db_path = match state.config.db_path() {
+        Ok(path) => path,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("Failed to determine database path: {}", e)
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let db = match Database::new(&db_path) {
         Ok(db) => db,
         Err(e) => {
             return (


### PR DESCRIPTION
## Summary
Fixes a bug where the server API crashes or behaves unexpectedly when the current directory cannot be determined, leading to an empty database path.

## Problem
When std::env::current_dir() fails, config.db_path() returns an error. The current implementation in pi.rs uses .unwrap_or_default() which results in an empty path string. This is passed to Database::new(), potentially causing initialization failures or creating/accessing a database at an invalid location.

## Solution
Explicitly handle the Result from config.db_path() in status and search endpoints. If the path cannot be determined, return a 500 Internal Server Error with a descriptive message instead of silently falling back to a default empty path.

## Testing
- Verified code compilation (fix is logic-based standard error handling).
- The change ensures that failure to determine context results in a clear error rather than undefined behavior.

## Related Issue
Fixes PlatformNetwork/bounty-challenge#44