### PR TITLE
Fix: Indexer logs file read errors instead of swallowing them

### DIFF
--- a/src/core/indexer.rs
+++ b/src/core/indexer.rs
@@ -101,7 +101,11 @@ impl Indexer {
                     pending_files.push(pending);
                 }
                 Ok(None) => skipped += 1,
-                Err(_) => skipped += 1,
+                Err(e) => {
+                    let error_msg = format!("Failed to read file {}: {}", file_path.display(), e);
+                    pb.println(format!("    {} {}", ui::WARN, style(error_msg).yellow()));
+                    skipped += 1;
+                }
             }
 
             pb.inc(1);
@@ -469,7 +473,11 @@ impl ServerIndexer {
                     pending_files.push(pending);
                 }
                 Ok(None) => skipped += 1,
-                Err(_) => skipped += 1,
+                Err(e) => {
+                    let error_msg = format!("Failed to read file {}: {}", file_path.display(), e);
+                    pb.println(format!("    {} {}", ui::WARN, style(error_msg).yellow()));
+                    skipped += 1;
+                }
             }
 
             pb.inc(1);


### PR DESCRIPTION
## Summary

Modified the indexer to log specific file read errors instead of silently incrementing the 'skipped' counter.

## Problem

Previously, when the indexer encountered an error reading a file (e.g., permission denied, invalid UTF-8), it caught the error generically with Err(_) => skipped += 1, giving the user no indication of why files were skipped or which files failed.

## Solution

Updated the match block in both Indexer and ServerIndexer to capture the error Err(e) and print a warning message with the file path and error details using pb.println. This ensures the progress bar display remains intact while informing the user of issues.

## Testing

Confirmed via code analysis that the Err(_) arm was swallowing errors. The fix now explicitly logs Failed to read file {path}: {error} to the console.

## Related Issue

Fixes PlatformNetwork/bounty-challenge#47