### PR TITLE
feat(ui): add OSC 8 hyperlink support for model URLs

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -975,8 +975,9 @@ fn run_models(action: ModelsAction, config: &mut Config) -> Result<()> {
             );
             println!("     {} ~600MB", style("Size:").dim());
             println!(
-                "     {} https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF",
-                style("URL:").dim()
+                "     {} {}",
+                style("URL:").dim(),
+                ui::hyperlink("https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF", "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF")
             );
             println!();
             println!(
@@ -990,8 +991,9 @@ fn run_models(action: ModelsAction, config: &mut Config) -> Result<()> {
             );
             println!("     {} ~400MB", style("Size:").dim());
             println!(
-                "     {} https://huggingface.co/sinjab/Qwen3-Reranker-0.6B-Q4_K_M-GGUF",
-                style("URL:").dim()
+                "     {} {}",
+                style("URL:").dim(),
+                ui::hyperlink("https://huggingface.co/sinjab/Qwen3-Reranker-0.6B-Q4_K_M-GGUF", "https://huggingface.co/sinjab/Qwen3-Reranker-0.6B-Q4_K_M-GGUF")
             );
             println!();
             println!("  Download with: {}", style("vgrep models download").cyan());

--- a/src/ui/console.rs
+++ b/src/ui/console.rs
@@ -14,6 +14,17 @@ pub static EYE: Emoji<'_, '_> = Emoji("👁️  ", "");
 pub static SPARKLES: Emoji<'_, '_> = Emoji("✨ ", "");
 pub static BRAIN: Emoji<'_, '_> = Emoji("🧠 ", "");
 
+/// Create a clickable hyperlink using OSC 8 escape sequence.
+/// Falls back to plain text display in unsupporting terminals.
+pub fn hyperlink(url: &str, text: &str) -> String {
+    format!("\x1b]8;;{}\x07{}\x1b]8;;\x07", url, text)
+}
+
+/// Create a hyperlink where the URL is also the display text.
+pub fn hyperlink_url(url: &str) -> String {
+    hyperlink(url, url)
+}
+
 pub fn print_banner() {
     let banner = r#"
                                 


### PR DESCRIPTION
### Description

This PR implements OSC 8 hyperlink support for the \grep models info\ command, addressing [Issue #63](https://github.com/PlatformNetwork/bounty-challenge/issues/63).

### Changes

- Added \hyperlink\ and \hyperlink_url\ helper functions in \src/ui/console.rs\ which generate the appropriate OSC 8 escape sequences.
- Updated \src/cli/commands.rs\ to use these helpers when displaying model download URLs.

### Why

Currently, model URLs are displayed as plain text, requiring users to manually copy and paste them. Modern terminals support clickable hyperlinks, which significantly improves the user experience.

### Verification

I have verified the implementation logic with a test case ensuring the correct OSC 8 escape sequences are generated.

\\\ust
\x1b]8;;https://example.com\x07https://example.com\x1b]8;;\x07
\\\
