### PR TITLE
fix: reject empty search queries

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -548,6 +548,12 @@ fn run_search_smart(
     interactive: bool,
     sync: bool,
 ) -> Result<()> {
+    let query = query.trim();
+    if query.is_empty() {
+        ui::print_error("Search query cannot be empty");
+        return Ok(());
+    }
+
     if sync {
         run_index(
             config,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -59,3 +59,23 @@ fn test_config_show() {
         .success()
         .stdout(predicate::str::contains("Chunk size"));
 }
+
+#[test]
+fn test_search_empty_query_should_fail() {
+    vgrep()
+        .arg("search")
+        .arg("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Search query cannot be empty"));
+}
+
+#[test]
+fn test_search_whitespace_query_should_fail() {
+    vgrep()
+        .arg("search")
+        .arg("   ")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Search query cannot be empty"));
+}


### PR DESCRIPTION
Resolves #66. Adds validation to reject empty or whitespace-only search queries to prevent wasted resources and confusion.