### PR TITLE
fix: escape SQL LIKE special characters to prevent query manipulation

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -159,7 +159,12 @@ impl Database {
         limit: usize,
     ) -> Result<Vec<SearchResult>> {
         let path_prefix_str = path_prefix.to_string_lossy();
-        let like_pattern = format!("{}%", path_prefix_str);
+        // Escape SQL LIKE special characters to prevent query manipulation
+        let escaped = path_prefix_str
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let like_pattern = format!("{}%", escaped);
 
         let mut stmt = self.conn.prepare(
             r"SELECT c.id, c.file_id, f.path, c.content, c.start_line, c.end_line, c.embedding


### PR DESCRIPTION
## Summary

The `search_similar` function in `db.rs` was vulnerable to SQL LIKE pattern manipulation because user-provided path input was directly concatenated into the LIKE pattern without escaping special characters.

## Problem

When constructing the LIKE pattern, the code used:
```rust
let like_pattern = format!("{}%", path_prefix_str);
```

This allowed attackers to inject SQL LIKE wildcards (`%`, `_`) in the path parameter, potentially matching unintended paths and accessing data from paths they should not see.

## Solution

Escape SQL LIKE special characters before constructing the pattern:
```rust
let escaped = path_prefix_str
    .replace('\\', "\\\\")
    .replace('%', "\\%")
    .replace('_', "\\_");
let like_pattern = format!("{}%", escaped);
```

This ensures that user-supplied wildcards are treated as literal characters rather than SQL pattern metacharacters.

## Testing

The fix properly escapes:
- `%` -> `\%` (no longer acts as zero-or-more wildcard)
- `_` -> `\_` (no longer acts as single-character wildcard)
- `\` -> `\\` (proper escape sequence handling)

Fixes PlatformNetwork/bounty-challenge#62
