### PR TITLE
fix: handle TOCTOU race condition in file watcher

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -315,6 +315,20 @@ impl FileWatcher {
             // File was created or modified
             let content = match std::fs::read_to_string(path) {
                 Ok(c) => c,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // File was deleted between check and read (TOCTOU)
+                    if let Some(entry) = db.get_file_by_path(path)? {
+                        db.delete_file(entry.id)?;
+                        println!(
+                            "  {} {} {} {}",
+                            style("[-]").red(),
+                            style("removed").red(),
+                            style(filename).dim(),
+                            style("(race condition handled)").dim()
+                        );
+                    }
+                    continue;
+                }
                 Err(_) => continue, // Skip binary or unreadable files
             };
 


### PR DESCRIPTION
### Description

The `process_files()` function in `src/watcher.rs` had a time-of-check to time-of-use (TOCTOU) race condition. A file could be deleted between the `path.exists()` check and the subsequent `read_to_string()` call, causing silent failures.

This PR addresses the issue by handling `ErrorKind::NotFound` when reading the file. If the file is not found during the read operation, it is treated as deleted and removed from the index.

### Changes

- Modified `process_files` in `src/watcher.rs` to match on `read_to_string` result.
- Added a match arm for `ErrorKind::NotFound` to handle the race condition.
- When `NotFound` occurs, the code now attempts to remove the file from the database and logs the race condition handling.

### Verification

- I have verified that the code compiles.
- Existing tests pass.
- The logic specifically targets the described race condition where `path.exists()` returns true but the file is gone by the time `read_to_string()` is called.
