### PR TITLE
fix: limit http response size to 10MB to prevent DoS

### DIFF
--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -98,8 +98,8 @@ impl Client {
             }
         }
 
-        // Read body
-        reader.read_to_string(&mut response)?;
+        // Read body with 10MB limit
+        reader.take(10 * 1024 * 1024).read_to_string(&mut response)?;
 
         let search_response: SearchResponse =
             serde_json::from_str(&response).context("Failed to parse server response")?;
@@ -146,8 +146,8 @@ impl Client {
             }
         }
 
-        // Read body
-        reader.read_to_string(&mut response)?;
+        // Read body with 10MB limit
+        reader.take(10 * 1024 * 1024).read_to_string(&mut response)?;
 
         let embed_response: EmbedBatchResponse =
             serde_json::from_str(&response).context("Failed to parse server response")?;


### PR DESCRIPTION
### Description

This PR addresses a potential DoS vulnerability where the HTTP client reads the response body without any size limits. This could allow a malicious server to exhaust memory by sending an unlimited amount of data.

### Changes

- Added a 10MB limit to the response body reading in `src/server/client.rs` using `reader.take(10 * 1024 * 1024)`.

### Verification

- Created a reproduction test case that simulates a malicious server sending >20MB of data.
- Verified that the client now limits the read operation and does not consume unlimited memory.
- Ran existing tests to ensure no regressions.