### PR TITLE
fix: enforce batch size and text length limits in embed API

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -55,6 +55,9 @@ pub struct EmbedRequest {
     pub text: String,
 }
 
+const MAX_BATCH_SIZE: usize = 100;
+const MAX_TEXT_LENGTH: usize = 8192; // Common token limit for many models
+
 #[derive(Debug, Deserialize)]
 pub struct EmbedBatchRequest {
     pub texts: Vec<String>,
@@ -303,6 +306,16 @@ async fn embed(
     State(state): State<SharedState>,
     Json(req): Json<EmbedRequest>,
 ) -> impl IntoResponse {
+    if req.text.len() > MAX_TEXT_LENGTH {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("Text exceeds length limit of {}", MAX_TEXT_LENGTH)
+            })),
+        )
+            .into_response();
+    }
+
     let engine = match state.embedding_engine.lock() {
         Ok(e) => e,
         Err(e) => {
@@ -339,6 +352,28 @@ async fn embed_batch(
     State(state): State<SharedState>,
     Json(req): Json<EmbedBatchRequest>,
 ) -> impl IntoResponse {
+    if req.texts.len() > MAX_BATCH_SIZE {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("Batch size exceeds limit of {}", MAX_BATCH_SIZE)
+            })),
+        )
+            .into_response();
+    }
+
+    for (i, text) in req.texts.iter().enumerate() {
+        if text.len() > MAX_TEXT_LENGTH {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!("Text at index {} exceeds length limit of {}", i, MAX_TEXT_LENGTH)
+                })),
+            )
+                .into_response();
+        }
+    }
+
     let engine = match state.embedding_engine.lock() {
         Ok(e) => e,
         Err(e) => {


### PR DESCRIPTION
This PR mitigates a potential Denial of Service (DoS) vulnerability by enforcing limits on the `/embed_batch` and `/embed` API endpoints.

### Changes
- Added `MAX_BATCH_SIZE = 100` for `/embed_batch` requests.
- Added `MAX_TEXT_LENGTH = 8192` (characters) for individual text items in both `/embed` and `/embed_batch`.
- Requests exceeding these limits now return `400 Bad Request` immediately, preventing memory exhaustion and server unresponsiveness.

### Verification
- Verified with a reproduction script sending 10,000 items, which was correctly rejected with 400 Bad Request.
- Verified that requests with over-sized text are rejected.
- Verified that valid requests still pass.
- Ran existing tests to ensure no regressions.