### PR TITLE
fix: prevent multiplication overflow in search limit calculation

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -194,7 +194,9 @@ impl Database {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
-        results.truncate(limit * 3); // Get more for reranking
+        // Use saturating multiplication to prevent overflow
+        let effective_limit = limit.saturating_mul(3);
+        results.truncate(effective_limit); // Get more for reranking
         Ok(results)
     }
 
@@ -302,4 +304,31 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     }
 
     (dot / (norm_a.sqrt() * norm_b.sqrt())) as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::panic::AssertUnwindSafe;
+
+    #[test]
+    fn test_search_similar_overflow() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db = Database::new(&db_path).unwrap();
+        
+        // Ensure checked_mul/saturating_mul is needed
+        let huge_limit = (usize::MAX / 3) + 1;
+        let query_embedding = vec![0.0; 10];
+        let path = Path::new("/");
+        
+        // This should NO LONGER panic
+        let db_ref = AssertUnwindSafe(&db);
+        let result = std::panic::catch_unwind(move || {
+            db_ref.search_similar(&query_embedding, path, huge_limit).unwrap();
+        });
+
+        assert!(result.is_ok());
+    }
 }

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -45,10 +45,11 @@ impl SearchEngine {
         // Generate query embedding
         let query_embedding = self.embedding_engine.embed(query)?;
 
-        // Search for similar chunks
+        // Search for similar chunks with overflow protection
+        let limit = max_results.saturating_mul(3);
         let candidates = self
             .db
-            .search_similar(&query_embedding, &abs_path, max_results * 3)?;
+            .search_similar(&query_embedding, &abs_path, limit)?;
 
         if candidates.is_empty() {
             return Ok(Vec::new());


### PR DESCRIPTION
### Description
This PR fixes a potential panic caused by integer overflow when multiplying `max_results` by 3 in search queries.

### Changes
- Changed multiplication to `saturating_mul` in `src/core/search.rs` and `src/core/db.rs`.
- Added a regression test case in `src/core/db.rs` to verify the fix works for large limit values.

### Verification
- Ran `cargo test` and verified the new test case passes.
- Verified that existing functionality is preserved.