### PR TITLE
fix: Enable WAL mode and set busy timeout for SQLite

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -47,6 +47,16 @@ pub struct DatabaseStats {
 impl Database {
     pub fn new(path: &Path) -> Result<Self> {
         let conn = Connection::open(path)?;
+        
+        // Enable WAL mode for better concurrency and write performance
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        
+        // Set a busy timeout to handle lock contention gracefully (5 seconds)
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
+        
+        // Set synchronous mode to NORMAL for better performance while maintaining safety in WAL mode
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        
         let db = Self { conn };
         db.init_schema()?;
         Ok(db)


### PR DESCRIPTION
### Description
This PR addresses the issue where the database could become locked during concurrent operations (e.g., watcher running while searching). It enables Write-Ahead Logging (WAL) mode for SQLite and sets a busy timeout to handle lock contention more gracefully.

### Changes
- Enabled WAL journal mode.
- Set a busy timeout of 5 seconds.
- Set synchronous mode to NORMAL.

### Verification
I reproduced the issue with a test script that simulated concurrent read/write operations, which failed with 'database is locked'. After applying the fix, the test passed successfully. Existing tests also pass.