### PR TITLE
fix: validate downloaded model files

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -8,6 +8,7 @@ use crate::config::{Config, Mode};
 use crate::core::{Database, EmbeddingEngine, Indexer, SearchEngine, ServerIndexer};
 use crate::server::{self, Client};
 use crate::ui::{self, SearchTui};
+use crate::utils::validation;
 use crate::watcher::FileWatcher;
 
 #[derive(Parser)]
@@ -867,9 +868,21 @@ fn run_models(action: ModelsAction, config: &mut Config) -> Result<()> {
                     .get("Qwen3-Embedding-0.6B-Q8_0.gguf")?;
 
                 pb.finish_and_clear();
-                ui::print_success(&format!("Downloaded: {}", embedding_path.display()));
-
-                config.set_embedding_model(embedding_path.to_string_lossy().to_string())?;
+                
+                // Validate the downloaded file
+                println!("    Validating embedding model...");
+                match validation::validate_model_file(&embedding_path, 100 * 1024 * 1024) {
+                    Ok(_) => {
+                        ui::print_success(&format!("Downloaded: {}", embedding_path.display()));
+                        config.set_embedding_model(embedding_path.to_string_lossy().to_string())?;
+                    },
+                    Err(e) => {
+                        ui::print_error(&format!("Validation failed: {}", e));
+                        println!("    Deleting corrupted file...");
+                        let _ = std::fs::remove_file(&embedding_path);
+                        return Err(e);
+                    }
+                }
             }
 
             if !embedding_only {
@@ -894,9 +907,21 @@ fn run_models(action: ModelsAction, config: &mut Config) -> Result<()> {
                     .get("Qwen3-Reranker-0.6B-Q4_K_M.gguf")?;
 
                 pb.finish_and_clear();
-                ui::print_success(&format!("Downloaded: {}", reranker_path.display()));
-
-                config.set_reranker_model(reranker_path.to_string_lossy().to_string())?;
+                
+                // Validate the downloaded file
+                println!("    Validating reranker model...");
+                match validation::validate_model_file(&reranker_path, 100 * 1024 * 1024) {
+                    Ok(_) => {
+                        ui::print_success(&format!("Downloaded: {}", reranker_path.display()));
+                        config.set_reranker_model(reranker_path.to_string_lossy().to_string())?;
+                    },
+                    Err(e) => {
+                        ui::print_error(&format!("Validation failed: {}", e));
+                        println!("    Deleting corrupted file...");
+                        let _ = std::fs::remove_file(&reranker_path);
+                        return Err(e);
+                    }
+                }
             }
 
             println!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod core;
 pub mod server;
 pub mod ui;
+pub mod utils;
 pub mod watcher;
 
 pub use config::Config;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod validation;

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -1,0 +1,33 @@
+use anyhow::{Result, Context};
+use std::fs;
+use std::path::Path;
+
+// Helper function to validate a model file
+pub fn validate_model_file(path: &Path, expected_size_min: u64) -> Result<()> {
+    // 1. Check if file exists
+    if !path.exists() {
+        anyhow::bail!("Model file does not exist at {}", path.display());
+    }
+
+    // 2. Check file size
+    let metadata = fs::metadata(path)?;
+    if metadata.len() < expected_size_min {
+        anyhow::bail!(
+            "Model file size too small: {} bytes (expected at least {})",
+            metadata.len(),
+            expected_size_min
+        );
+    }
+    
+    // 3. Try to verify GGUF header (first 4 bytes should be 'GGUF')
+    let mut file = fs::File::open(path)?;
+    use std::io::Read;
+    let mut buffer = [0u8; 4];
+    file.read_exact(&mut buffer).context("Failed to read file header")?;
+    
+    if &buffer != b"GGUF" {
+         anyhow::bail!("Invalid file format: Header is not 'GGUF'");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds basic validation for downloaded model files to prevent using corrupted or incomplete files.

### Changes
- Added a new `utils::validation` module.
- Implemented checks for:
  - File existence
  - Minimum file size (100MB check for models)
  - GGUF header verification (first 4 bytes)
- Updated `models download` command to validate files immediately after download.
- If validation fails, the corrupted file is deleted and an error is reported.

### Reasoning
Previously, network interruptions or other issues could result in corrupted files being saved and configured, leading to cryptic errors during search or server startup. This change ensures that only valid GGUF files are accepted.