### PR TITLE
fix: handle NaN and Infinity in embedding normalization

### DIFF
--- a/src/core/embeddings.rs
+++ b/src/core/embeddings.rs
@@ -131,10 +131,15 @@ impl EmbeddingEngine {
     }
 }
 
-fn normalize(input: &[f32]) -> Vec<f32> {
+pub(crate) fn normalize(input: &[f32]) -> Vec<f32> {
+    // Check for NaN or Infinity in input
+    if input.iter().any(|x| x.is_nan() || x.is_infinite()) {
+        return vec![0.0; input.len()];
+    }
+
     let magnitude: f32 = input.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if magnitude == 0.0 {
-        return input.to_vec();
+    if magnitude == 0.0 || magnitude.is_nan() || magnitude.is_infinite() {
+        return vec![0.0; input.len()];
     }
     input.iter().map(|x| x / magnitude).collect()
 }


### PR DESCRIPTION
This PR fixes a bug where NaN and Infinity values in embeddings would propagate silently, causing undefined behavior in similarity scores and sort ordering.

The `normalize` function now checks for NaN or Infinity in the input vector. If detected, it returns a zero vector instead of propagating the invalid values. It also handles cases where the magnitude calculation results in NaN or Infinity.

Fixes issue #150.