### PR TITLE
fix: Log warning when input text is truncated to context limit

### DIFF
--- a/src/core/embeddings.rs
+++ b/src/core/embeddings.rs
@@ -96,6 +96,11 @@ impl EmbeddingEngine {
                 .context("Failed to tokenize")?;
 
             let tokens: Vec<_> = if tokens.len() > self.n_ctx {
+                eprintln!(
+                    "Warning: Input text truncated from {} to {} tokens (context limit)",
+                    tokens.len(),
+                    self.n_ctx
+                );
                 tokens.into_iter().take(self.n_ctx).collect()
             } else {
                 tokens


### PR DESCRIPTION
### Description
This PR addresses the issue of silent token truncation when input text exceeds the context size limit. Previously, tokens were dropped without any indication to the user, potentially leading to incomplete embeddings and misleading search results.

### Changes
- Added a warning log to `src/core/embeddings.rs` that prints to stderr when truncation occurs.
- The warning includes the original token count and the truncated (context limit) count.

### Verification
- Verified by code inspection that the truncation logic now includes a warning side-effect.
- Existing tests pass.
