### PR TITLE
fix: sanitize host configuration to prevent HTTP header injection

### DIFF
--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -46,8 +46,13 @@ pub struct Client {
 
 impl Client {
     pub fn new(host: &str, port: u16) -> Self {
+        // Sanitize host to prevent CRLF injection
+        let clean_host: String = host.chars()
+            .filter(|c| !matches!(c, '\r' | '\n' | '\0'))
+            .collect();
+            
         Self {
-            base_url: format!("http://{}:{}", host, port),
+            base_url: format!("http://{}:{}", clean_host, port),
         }
     }
 


### PR DESCRIPTION
### Description
This PR addresses a security vulnerability (HTTP Header Injection / CRLF Injection) where unsanitized user input in the `host` configuration allowed attackers to inject arbitrary HTTP headers into outgoing requests.

### Changes
- Updated `Client::new` in `src/server/client.rs` to sanitize the `host` parameter.
- The sanitization process filters out Carriage Return (`\r`), Line Feed (`\n`), and Null (`\0`) characters from the host string before constructing the `base_url`.

### Verification
- Verified manually with a reproduction test case (locally created and then removed) that injecting CRLF sequences is no longer possible. The sanitized host strips these characters, preventing the injection.
- Existing tests pass.

### Related Issue
Fixes #179