### PR TITLE
fix: restore terminal state on panic

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,8 +9,29 @@ pub use interactive::run_interactive_config;
 
 use anyhow::Result;
 use clap::Parser;
+use crossterm::{
+    cursor, event, execute,
+    terminal::{disable_raw_mode, is_raw_mode_enabled, LeaveAlternateScreen},
+};
+use std::io;
 
 pub fn run() -> Result<()> {
+    // Set up global panic hook to restore terminal state on panic
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Only try to restore if we seem to be in raw mode (TUI active)
+        if let Ok(true) = is_raw_mode_enabled() {
+            let _ = disable_raw_mode();
+            let _ = execute!(
+                io::stdout(),
+                LeaveAlternateScreen,
+                event::DisableMouseCapture,
+                cursor::Show
+            );
+        }
+        default_hook(info);
+    }));
+
     let cli = Cli::parse();
     cli.run()
 }


### PR DESCRIPTION
## Description
This PR addresses the issue where a panic within the TUI (or while the terminal is in raw mode) would leave the terminal in a broken state (raw mode enabled, cursor hidden, alternate screen active).

## Changes
- Added a global panic hook in `src/cli/mod.rs` (the entry point for CLI commands).
- The hook checks `crossterm::terminal::is_raw_mode_enabled()` to determine if cleanup is necessary.
- If raw mode is enabled, it attempts to:
  - Disable raw mode
  - Leave alternate screen
  - Disable mouse capture
  - Show the cursor
- The original panic hook is then called to ensure panic messages are printed correctly.

## Verification
- Verified that `cargo check` and `cargo test` pass.
- Logic is based on standard `crossterm` and `ratatui` panic handling patterns, adapted for global application to avoid TUI-local wrapper complexity.