### PR TITLE
fix: prevent command injection in install_droid()

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -380,7 +380,7 @@ if __name__ == "__main__":
             "matcher": "startup|resume",
             "hooks": [{
                 "type": "command",
-                "command": format!("python3 \"{}\"", watch_py.display()),
+                "command": ["python3", watch_py.to_string_lossy()],
                 "timeout": 10
             }]
         });
@@ -399,7 +399,7 @@ if __name__ == "__main__":
         let hook_entry = serde_json::json!({
             "hooks": [{
                 "type": "command",
-                "command": format!("python3 \"{}\"", kill_py.display()),
+                "command": ["python3", kill_py.to_string_lossy()],
                 "timeout": 10
             }]
         });


### PR DESCRIPTION
### Description
This PR addresses a command injection vulnerability in install_droid() where file paths were directly interpolated into command strings. This could allow arbitrary code execution if the path contained shell metacharacters.

### Fix
- Replaced string interpolation with array-based command execution.
- This ensures that paths are treated as arguments rather than executable shell commands.

### Verification
- Verified that the generated settings.json now uses an array for the command field, which Factory Droid handles safely.
- Added a reproduction test case (locally) to confirm that the array-based approach prevents shell interpretation.