### PR TITLE
fix: validate embedding count in indexer to prevent panic

### DIFF
--- a/src/core/indexer.rs
+++ b/src/core/indexer.rs
@@ -138,6 +138,14 @@ impl Indexer {
 
         let all_embeddings = self.engine.embed_batch(&all_chunks)?;
 
+        if all_embeddings.len() != all_chunks.len() {
+            return Err(anyhow::anyhow!(
+                "Embedding count mismatch: expected {}, got {}",
+                all_chunks.len(),
+                all_embeddings.len()
+            ));
+        }
+
         pb.finish_and_clear();
         println!(
             "    {}Generated {} embeddings",
@@ -513,8 +521,25 @@ impl ServerIndexer {
         for batch in all_chunks.chunks(batch_size) {
             let batch_refs: Vec<&str> = batch.iter().map(|s| s.as_str()).collect();
             let embeddings = self.client.embed_batch(&batch_refs)?;
+            
+            if embeddings.len() != batch.len() {
+                return Err(anyhow::anyhow!(
+                    "Embedding count mismatch in batch: expected {}, got {}",
+                    batch.len(),
+                    embeddings.len()
+                ));
+            }
+
             all_embeddings.extend(embeddings);
             pb.inc(batch.len() as u64);
+        }
+
+        if all_embeddings.len() != all_chunks.len() {
+             return Err(anyhow::anyhow!(
+                "Total embedding count mismatch: expected {}, got {}",
+                all_chunks.len(),
+                all_embeddings.len()
+            ));
         }
 
         pb.finish_and_clear();


### PR DESCRIPTION
## Description
This PR addresses an issue where the indexer could panic with an "index out of bounds" error if the embedding engine returned fewer embeddings than the number of chunks provided.

## Changes
- Added validation in `Indexer::index_directory` to ensure the number of returned embeddings matches the number of chunks.
- Added validation in `ServerIndexer::index_directory` to ensure the number of returned embeddings matches the number of chunks, both per-batch and for the total count.
- The indexer now returns a descriptive error instead of panicking if a mismatch occurs.

## Reasoning
When the embedding API fails silently or partially (e.g., due to timeouts, memory limits, or network issues), it may return a partial list of embeddings. iterating over the chunks and accessing the embeddings by index without validation led to a panic. This fix ensures the application handles this failure mode gracefully.

## Testing
- Verified that the logic now checks the lengths before access.
- Existing tests passed.