### PR TITLE
fix: enable foreign key constraints in SQLite connection

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -47,6 +47,7 @@ pub struct DatabaseStats {
 impl Database {
     pub fn new(path: &Path) -> Result<Self> {
         let conn = Connection::open(path)?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
         let db = Self { conn };
         db.init_schema()?;
         Ok(db)


### PR DESCRIPTION
### Description

This PR fixes a bug where SQLite foreign key constraints were not being enforced, leading to orphaned chunks in the database when files were deleted or replaced.

SQLite does not enforce foreign keys by default, so they must be explicitly enabled for each connection. This change adds `PRAGMA foreign_keys = ON` to the database connection initialization.

### Fix Details

- Modified `Database::new` in `src/core/db.rs` to execute `PRAGMA foreign_keys = ON` immediately after opening the connection.

### Verification

I created a reproduction script that simulates the issue:
1. Insert a file.
2. Insert a chunk linked to that file.
3. Perform an `INSERT OR REPLACE` on the file (which deletes the old file row).
4. Verify if the chunk remains (orphaned) or is deleted.

**Before Fix:**
The chunk remained orphaned because the cascade delete was not triggered.

**After Fix:**
The chunk is correctly deleted via the `ON DELETE CASCADE` constraint.

Also ran existing tests with `cargo test` and they passed.
