### PR TITLE
fix: mitigate hash collision risk by using full SHA256 hash

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -262,7 +262,7 @@ impl Config {
         let mut hasher = Sha256::new();
         hasher.update(path.as_bytes());
         let result = hasher.finalize();
-        hex::encode(&result[..8]) // First 8 bytes = 16 hex chars
+        hex::encode(result) // Use full SHA256 hash (32 bytes = 64 hex chars)
     }
 
     /// Get full path to embedding model


### PR DESCRIPTION
## Problem
The previous implementation used only the first 8 bytes (64 bits) of the SHA256 hash for generating project database filenames. This limited the hash space significantly, increasing the risk of collisions via the birthday paradox as the number of projects grows. A collision would result in two different projects sharing the same database file, leading to data corruption.

## Solution
This PR changes the `hash_path` function in `src/config.rs` to use the full SHA256 hash (32 bytes / 64 hex characters) instead of truncating it. This effectively eliminates the risk of accidental collision for all practical purposes.

## Testing
- Verified that `hash_path` now returns a 64-character hex string.
- Ran existing tests with `cargo test` to ensure no regressions.