### PR TITLE
fix: prevent shell injection in python hooks

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -380,7 +380,7 @@ if __name__ == "__main__":
             "matcher": "startup|resume",
             "hooks": [{
                 "type": "command",
-                "command": format!("python3 \"{}\"", watch_py.display()),
+                "command": ["python3", watch_py.display().to_string()],
                 "timeout": 10
             }]
         });
@@ -399,7 +399,7 @@ if __name__ == "__main__":
         let hook_entry = serde_json::json!({
             "hooks": [{
                 "type": "command",
-                "command": format!("python3 \"{}\"", kill_py.display()),
+                "command": ["python3", kill_py.display().to_string()],
                 "timeout": 10
             }]
         });


### PR DESCRIPTION
### Description
This PR addresses a shell command injection vulnerability in `install_droid()` where python hook paths were directly interpolated into command strings using `format!`. If the path contained shell metacharacters, it could lead to arbitrary command execution.

### Fix
- Changed the command execution from a string (which is parsed by the shell) to an array of arguments (which is passed directly to the process).
- Replaced `format!("python3 \"{}\"", path.display())` with `["python3", path.display().to_string()]`.

### Verification
- This change ensures that the path is treated as a single argument to `python3`, preventing any shell interpretation of special characters within the path.
- Existing tests passed.