### PR TITLE
fix: deduplicate search results by file_id to handle symlinks correctly

### DIFF
--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -55,11 +55,12 @@ impl SearchEngine {
         }
 
         // Deduplicate by file (keep best chunk per file)
-        let mut best_per_file: HashMap<PathBuf, DbSearchResult> = HashMap::new();
+        // Use file_id for deduplication to handle symlinks correctly
+        let mut best_per_file: HashMap<i64, DbSearchResult> = HashMap::new();
 
         for result in candidates {
             let entry = best_per_file
-                .entry(result.path.clone())
+                .entry(result.file_id)
                 .or_insert(result.clone());
             if result.similarity > entry.similarity {
                 *entry = result;


### PR DESCRIPTION
This PR fixes a bug where search result deduplication was incorrectly merging results from different logical files (e.g. symlinks) that resolved to the same path. By using 'file_id' instead of 'path' for deduplication, we ensure that the best chunk is kept for each indexed file entry, preserving results from distinct logical locations as expected.