### PR TITLE
fix: handle NaN scores in sort_by comparison

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -187,11 +187,19 @@ impl Database {
             .filter_map(Result::ok)
             .collect();
 
-        // Sort by similarity (highest first)
+        // Sort by similarity (highest first), handling NaNs
         results.sort_by(|a, b| {
-            b.similarity
-                .partial_cmp(&a.similarity)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            if b.similarity.is_nan() && a.similarity.is_nan() {
+                std::cmp::Ordering::Equal
+            } else if b.similarity.is_nan() {
+                std::cmp::Ordering::Less
+            } else if a.similarity.is_nan() {
+                std::cmp::Ordering::Greater
+            } else {
+                b.similarity
+                    .partial_cmp(&a.similarity)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            }
         });
 
         results.truncate(limit * 3); // Get more for reranking

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -78,11 +78,19 @@ impl SearchEngine {
             })
             .collect();
 
-        // Sort by score descending
+        // Sort by score descending, handling NaNs by pushing them to the end
         results.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            if b.score.is_nan() && a.score.is_nan() {
+                std::cmp::Ordering::Equal
+            } else if b.score.is_nan() {
+                std::cmp::Ordering::Less
+            } else if a.score.is_nan() {
+                std::cmp::Ordering::Greater
+            } else {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            }
         });
 
         results.truncate(max_results);


### PR DESCRIPTION
### Description

This PR fixes a bug where  scores (potentially from embedding engine or numerical issues) would cause non-deterministic sorting behavior in search results due to the use of  with .

### Changes

- Updated  logic in  to explicitly handle  values by treating them as smaller than any other number (pushing them to the end of the sorted list).
- Applied the same fix to  where similarity scores are sorted.

### Verification

- Created a reproduction test case demonstrating that the old sort was unstable with NaNs.
- Verified that the new sort correctly orders real numbers descending and pushes NaNs to the end.
- Ran existing test suite to ensure no regressions.