### PR TITLE
fix: prevent cursor overflow with long input

### DIFF
--- a/src/ui/search_tui.rs
+++ b/src/ui/search_tui.rs
@@ -217,7 +217,10 @@ impl SearchTui {
 
         // Show cursor in input mode
         if self.mode == Mode::Input {
-            f.set_cursor_position((area.x + self.input.len() as u16 + 1, area.y + 1));
+            // Calculate cursor position safely, constraining it to the input area
+            let max_input_width = area.width.saturating_sub(2); // borders
+            let input_len = self.input.len().min(max_input_width as usize) as u16;
+            f.set_cursor_position((area.x + input_len + 1, area.y + 1));
         }
     }
 


### PR DESCRIPTION
### Description
This PR addresses an issue where extremely long input strings in the search TUI could cause an integer overflow when calculating the cursor position. The cursor position calculation now clamps the input length to the visible input area width, ensuring it fits within `u16` and remains within the bounds of the terminal area.

### Changes
- Updated `search_tui.rs` to calculate `max_input_width` based on area width minus borders.
- Clamped `input_len` to the minimum of the actual input length and `max_input_width`, casting strictly to `u16` only after clamping.
- Updated `set_cursor_position` to use the safe, clamped value.

### Verification
- Verified manually with a reproduction test case that simulated the overflow condition.
- The cursor is now correctly positioned at the end of the visible input area even when the input string exceeds `u16::MAX`.