### PR TITLE
fix: prevent potential panic in search navigation with empty results

### DIFF
--- a/src/ui/search_tui.rs
+++ b/src/ui/search_tui.rs
@@ -153,7 +153,7 @@ impl SearchTui {
 
         let i = match self.list_state.selected() {
             Some(i) => {
-                if i >= self.results.len() - 1 {
+                if i >= self.results.len().saturating_sub(1) {
                     0
                 } else {
                     i + 1
@@ -172,7 +172,7 @@ impl SearchTui {
         let i = match self.list_state.selected() {
             Some(i) => {
                 if i == 0 {
-                    self.results.len() - 1
+                    self.results.len().saturating_sub(1)
                 } else {
                     i - 1
                 }


### PR DESCRIPTION
This PR fixes a potential race condition/panic in the TUI navigation logic.

**Changes:**
- Used `saturating_sub(1)` instead of direct subtraction for `results.len() - 1` in `next()` and `previous()` methods.
- This ensures that even if `results` becomes empty between the initial check and the access (though unlikely in single-threaded contexts, it hardens the code against future changes or edge cases), the index calculation will not panic due to underflow.

**Verification:**
- Verified via code inspection that logic handles `len() == 0` safely (returning 0, which is handled gracefully by Ratatui or subsequent logic).
- Ran existing tests (`cargo test`) to ensure no regressions.