### PR TITLE
fix: prevent max_results=0 in search command

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -259,6 +259,11 @@ impl Cli {
         if self.command.is_none() && !self.query.is_empty() {
             let query = self.query.join(" ");
             let max_results = self.max_results.unwrap_or(config.max_results);
+
+            if max_results == 0 {
+                anyhow::bail!("max_results must be greater than 0");
+            }
+
             let show_content = self.content || config.show_content;
             return run_search_smart(
                 &config,
@@ -293,6 +298,11 @@ impl Cli {
                 let max_results = max_results
                     .or(self.max_results)
                     .unwrap_or(config.max_results);
+
+                if max_results == 0 {
+                    anyhow::bail!("max_results must be greater than 0");
+                }
+
                 let content = content || self.content || config.show_content;
                 run_search_smart(
                     &config,


### PR DESCRIPTION
This PR fixes a bug where setting max_results=0 would silently return empty results. Now it returns an error if max_results is 0.