### PR TITLE
fix: improve error message for invalid config mode

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1076,7 +1076,9 @@ fn run_config(action: Option<ConfigAction>, config: &mut Config) -> Result<()> {
         Some(ConfigAction::Set { key, value }) => {
             let result = match key {
                 ConfigKey::Mode => {
-                    let mode: Mode = value.parse()?;
+                    let mode: Mode = value.parse().map_err(|_| {
+                        anyhow::anyhow!("Invalid mode '{}'. Valid values are: server, local", value)
+                    })?;
                     config.set_mode(mode)?;
                     format!("mode = {}", mode)
                 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -59,3 +59,12 @@ fn test_config_show() {
         .success()
         .stdout(predicate::str::contains("Chunk size"));
 }
+
+#[test]
+fn test_config_set_invalid_mode() {
+    vgrep()
+        .args(["config", "set", "mode", "invalid_value"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid mode 'invalid_value'. Valid values are: server, local"));
+}


### PR DESCRIPTION
The `vgrep config set mode` command previously relied on the default error propagation which could result in generic or unclear error messages for some users.

This change explicitly handles parsing errors for the `mode` configuration key, ensuring that invalid values result in a clear error message that lists the valid options (`server`, `local`).

This change also adds a regression test to verify the error message.