### PR TITLE
fix: gracefully handle permission errors in run_watch

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -744,6 +744,18 @@ fn run_watch(config: &Config, path: PathBuf) -> Result<()> {
         }
     }
 
+    // Check if path exists and has valid permissions
+    if !path.exists() {
+        use anyhow::bail;
+        bail!("Path does not exist: {}", path.display());
+    }
+
+    // Try to access the directory to check permissions
+    if let Err(e) = std::fs::read_dir(&path) {
+        use anyhow::bail;
+        bail!("Failed to access directory '{}': {}. Check permissions.", path.display(), e);
+    }
+
     let watcher = FileWatcher::new(config.clone(), path);
     watcher.watch()
 }


### PR DESCRIPTION
## Description
This PR addresses issue #194 by adding checks for path existence and read permissions before initializing the file watcher in `run_watch`.

## Changes
- Added a check if the path exists.
- Added a check if the path is readable (by attempting `read_dir`).
- Used `anyhow::bail!` to return clear error messages to the user instead of propagating generic IO errors or crashing later.

## Testing
- Verified with non-existent directory -> Correctly reports "Path does not exist".
- Verified with existing directory -> Proceed to watch.
- (Implicitly) Permission denied on `read_dir` will now report "Failed to access directory ... Check permissions.".

## Checklist
- [x] Code compiles
- [x] Tests pass
- [x] Manual verification