### PR TITLE
fix: decouple debounce duration from poll interval in file watcher

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -80,7 +80,7 @@ impl FileWatcher {
                     let _ = tx.send(event);
                 }
             },
-            NotifyConfig::default().with_poll_interval(Duration::from_millis(self.debounce_ms)),
+            NotifyConfig::default(),
         )?;
 
         watcher.watch(&abs_path, RecursiveMode::Recursive)?;


### PR DESCRIPTION
### Description
This PR fixes a bug where the file watcher's poll interval was incorrectly set to the debounce duration. 

### Issue
Previously, setting a high debounce value (e.g., 5000ms) would cause the watcher to poll only every 5 seconds, effectively slowing down change detection instead of just batching events.

### Fix
The `notify` watcher is now initialized with the default configuration, allowing it to pick an appropriate poll interval (or use OS-native events). The debouncing logic remains separate and handles the batching of events as intended.

### Changes
- Removed `.with_poll_interval(Duration::from_millis(self.debounce_ms))` from watcher initialization in `src/watcher.rs`.
