### PR TITLE
fix: respect configured context_size in embed_batch

### DIFF
--- a/src/core/embeddings.rs
+++ b/src/core/embeddings.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::Once;
 
@@ -78,6 +79,7 @@ impl EmbeddingEngine {
             .unwrap_or(4);
 
         let ctx_params = LlamaContextParams::default()
+            .with_n_ctx(Some(NonZeroU32::new(self.n_ctx as u32).unwrap()))
             .with_n_threads_batch(n_threads)
             .with_n_threads(n_threads)
             .with_embeddings(true);


### PR DESCRIPTION
### Description

This PR fixes an issue where the configured `context_size` was ignored in `embed_batch()`. The function was initializing `LlamaContextParams` with defaults, causing it to use the model's default context size (usually 512) instead of the user's configuration.

### Fix Details

- Modified `embed_batch()` in `src/core/embeddings.rs` to explicitly set `.with_n_ctx(...)` using the stored `self.n_ctx`.
- This ensures that batch embedding operations respect the configured context window size.

### Verification

- Verified that `embed_batch()` now creates a context with the correct size.
- Ran existing tests with `cargo test`, all passed.

Fixes PlatformNetwork/bounty-challenge#200