### PR TITLE
fix: propagate error on search path canonicalization failure

### DIFF
--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -40,7 +40,7 @@ impl SearchEngine {
         path: &Path,
         max_results: usize,
     ) -> Result<Vec<SearchResult>> {
-        let abs_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let abs_path = std::fs::canonicalize(path)?;
 
         // Generate query embedding
         let query_embedding = self.embedding_engine.embed(query)?;


### PR DESCRIPTION
## Description
This PR addresses a security issue where search path canonicalization failures were silently ignored. Previously, if `std::fs::canonicalize` failed (e.g., due to a broken symlink or non-existent path), the code fell back to using the original raw path. This could allow operations on invalid or unverified paths.

## Changes
- Modified `src/core/search.rs` to propagate the error from `std::fs::canonicalize` instead of suppressing it with `unwrap_or_else`.

## Verification
- Reproduced the issue with a script that used a broken symlink.
- Verified that with this fix, the operation returns an error as expected instead of proceeding with the broken path.
- Ran existing tests (`cargo test`) to ensure no regressions.