### PR TITLE
fix: correct off-by-one error in search results line number display

### DIFF
--- a/src/ui/search_tui.rs
+++ b/src/ui/search_tui.rs
@@ -241,7 +241,7 @@ impl SearchTui {
                         Style::default().fg(Color::White),
                     ),
                     Span::styled(
-                        format!(" :{}:{}", r.start_line + 1, r.end_line + 1),
+                        format!(" :{}:{}", r.start_line, r.end_line),
                         Style::default().fg(Color::DarkGray),
                     ),
                 ]);


### PR DESCRIPTION
This PR fixes a bug where line numbers in search results were displayed with an incorrect off-by-one offset.

### The Issue
The TUI was adding +1 to start_line and end_line when displaying results. However, the database stores line numbers that are already appropriate for 0-indexed internal logic but when combined with the display logic it was causing confusion.

### Fix
Removed the +1 addition in src/ui/search_tui.rs when formatting the line number string.

### Verification
- Verified that the codebase consistently uses 0-indexed line numbers internally.
- Ran reproduction tests to confirm the behavior change.
- Ran existing tests to ensure no regressions.