### PR TITLE
fix: prevent max_file_size from being set to 0

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1113,6 +1113,9 @@ fn run_config(action: Option<ConfigAction>, config: &mut Config) -> Result<()> {
                 }
                 ConfigKey::MaxFileSize => {
                     let size: u64 = value.parse().context("Invalid size")?;
+                    if size == 0 {
+                        anyhow::bail!("Max file size must be greater than 0");
+                    }
                     config.set_max_file_size(size * 1024)?;
                     format!("max_file_size = {} KB", size)
                 }


### PR DESCRIPTION
## Description

This PR fixes a bug where setting `max_file_size` to 0 in the configuration was silently accepted, causing all files to be skipped during indexing.

## Changes

- Added validation in `commands.rs` to reject 0 as a value for `max-file-size`.
- If a user attempts to set it to 0, vgrep now returns an error: `Max file size must be greater than 0`.

## Verification

Reproduced the issue by running:
```bash
vgrep config set max-file-size 0
```
Before the fix, this succeeded. After the fix, it returns an error and prevents the invalid configuration.

Related to bounty issue #204.