### PR TITLE
fix: make agent install detection more specific

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -58,7 +58,7 @@ pub fn install_claude_code() -> Result<()> {
         String::new()
     };
 
-    if !content.contains("vgrep") {
+    if !content.contains("name: vgrep") {
         content.push_str("\n\n");
         content.push_str(VGREP_SKILL.trim());
         fs::write(&instructions_path, content)?;
@@ -225,7 +225,7 @@ pub fn install_codex() -> Result<()> {
         String::new()
     };
 
-    if !content.contains("vgrep") {
+    if !content.contains("name: vgrep") {
         content.push_str("\n\n");
         content.push_str(VGREP_SKILL.trim());
         fs::write(&agents_path, content)?;


### PR DESCRIPTION
### Description
This PR fixes a bug where the agent installer (for Claude Code and Codex) would falsely detect that vgrep is already installed if the configuration file (CLAUDE.md or AGENTS.md) contained any mention of the string "vgrep" (e.g. in comments or notes).

### Changes
- Updated the installation check in `src/cli/install.rs` to look for `name: vgrep` instead of just `vgrep`.
- This ensures we only detect the actual skill definition block, avoiding false positives from casual mentions.

### Verification
- Verified that casual mentions of "vgrep" no longer prevent installation.
- Verified that actual installation is still detected correctly.