### PR TITLE
Fix: Ensure progress bar is cleared on download error

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -862,11 +862,13 @@ fn run_models(action: ModelsAction, config: &mut Config) -> Result<()> {
                 pb.set_style(ProgressStyle::default_spinner().template("{spinner:.green} {msg}")?);
                 pb.set_message("Downloading...");
 
-                let embedding_path = api
+                let download_result = api
                     .model("Qwen/Qwen3-Embedding-0.6B-GGUF".to_string())
-                    .get("Qwen3-Embedding-0.6B-Q8_0.gguf")?;
+                    .get("Qwen3-Embedding-0.6B-Q8_0.gguf");
 
                 pb.finish_and_clear();
+                
+                let embedding_path = download_result?;
                 ui::print_success(&format!("Downloaded: {}", embedding_path.display()));
 
                 config.set_embedding_model(embedding_path.to_string_lossy().to_string())?;
@@ -889,11 +891,13 @@ fn run_models(action: ModelsAction, config: &mut Config) -> Result<()> {
                 pb.set_style(ProgressStyle::default_spinner().template("{spinner:.green} {msg}")?);
                 pb.set_message("Downloading...");
 
-                let reranker_path = api
+                let download_result = api
                     .model("sinjab/Qwen3-Reranker-0.6B-Q4_K_M-GGUF".to_string())
-                    .get("Qwen3-Reranker-0.6B-Q4_K_M.gguf")?;
+                    .get("Qwen3-Reranker-0.6B-Q4_K_M.gguf");
 
                 pb.finish_and_clear();
+
+                let reranker_path = download_result?;
                 ui::print_success(&format!("Downloaded: {}", reranker_path.display()));
 
                 config.set_reranker_model(reranker_path.to_string_lossy().to_string())?;


### PR DESCRIPTION
### Description

This PR fixes an issue where the download progress bar would remain visible if the model download failed, corrupting the terminal output.

### Changes
- Modified `run_models` in `src/cli/commands.rs` to separate the download call from the result handling.
- Ensures `pb.finish_and_clear()` is called before propagating any errors from the download operation.

### Verification
- Verified by code analysis and local reproduction simulation (not included in PR) where early return prevented cleanup.
- Ran existing tests: `cargo test` passes.