### PR TITLE
fix: handle Ctrl+C setup failure gracefully

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -59,10 +59,15 @@ impl FileWatcher {
         let running = Arc::new(AtomicBool::new(true));
         let r = running.clone();
 
-        ctrlc::set_handler(move || {
+        if let Err(e) = ctrlc::set_handler(move || {
             r.store(false, Ordering::SeqCst);
-        })
-        .expect("Error setting Ctrl+C handler");
+        }) {
+            eprintln!(
+                "{} Failed to set Ctrl+C handler: {}",
+                style("Warning:").yellow().bold(),
+                e
+            );
+        }
 
         // Initial index
         println!("  {} Initial indexing...", style(">>").dim());


### PR DESCRIPTION
### Description

The file watcher previously used `.expect()` when setting up the Ctrl+C handler, which could cause a panic in environments where signal handlers cannot be set (e.g., non-TTY contexts, containers). This PR changes the implementation to handle the error gracefully by logging a warning and continuing execution.

### Changes
- Replaced `ctrlc::set_handler(...).expect(...)` with `if let Err(e) = ctrlc::set_handler(...) { eprintln!(...); }`
- Logs a warning message if the signal handler cannot be installed, allowing the application to continue running.

### Verification
- Manual verification: Ran `vgrep watch < /dev/null` to ensure no regression in normal operation.
- Code inspection: Verified that the failure path no longer panics.