### PR TITLE
fix: remove ignored use_reranker parameter and add CLI warning

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -670,7 +670,11 @@ fn run_search_local(
 
     let db = Database::new(&config.db_path()?)?;
     let engine = EmbeddingEngine::new(config)?;
-    let search = SearchEngine::new(db, engine, config, config.use_reranker)?;
+    let search = SearchEngine::new(db, engine, config)?;
+
+    if config.use_reranker {
+        ui::print_warning("Reranking is currently disabled pending backend updates.");
+    }
 
     if interactive {
         let mut tui = SearchTui::new(search)?;

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -24,7 +24,6 @@ impl SearchEngine {
         db: Database,
         embedding_engine: EmbeddingEngine,
         _config: &Config,
-        _use_reranker: bool,
     ) -> Result<Self> {
         // Note: Reranker disabled for now as it requires a separate backend
         // which conflicts with the embedding engine's backend


### PR DESCRIPTION
This PR addresses issue #209 by removing the unused `_use_reranker` parameter from `SearchEngine::new` to clear up confusion. It also adds a warning message in the CLI when `use_reranker` is enabled in the configuration, informing the user that reranking is currently disabled pending backend updates.