### PR TITLE
fix: Implement rate limiting for API server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dialoguer = "0.12"
 console = "0.15"
 ctrlc = "3"
+tower_governor = "0.8.0"
+tower = "0.5.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use tower_http::cors::{Any, CorsLayer};
 
 use crate::config::Config;
@@ -108,6 +109,16 @@ pub async fn run_server(config: &Config, host: &str, port: u16) -> Result<()> {
         .allow_methods(Any)
         .allow_headers(Any);
 
+    // Rate limiting: 60 requests per second with a burst of 10
+    // This protects against simple DoS attacks and embedding abuse
+    let governor_conf = Arc::new(
+        GovernorConfigBuilder::default()
+            .per_second(60)
+            .burst_size(10)
+            .finish()
+            .unwrap(),
+    );
+
     let app = Router::new()
         .route("/", get(root))
         .route("/health", get(health))
@@ -116,6 +127,7 @@ pub async fn run_server(config: &Config, host: &str, port: u16) -> Result<()> {
         .route("/embed", post(embed))
         .route("/embed_batch", post(embed_batch))
         .layer(cors)
+        .layer(GovernorLayer::new(governor_conf))
         .with_state(state);
 
     let addr: SocketAddr = format!("{}:{}", host, port).parse()?;


### PR DESCRIPTION
This PR addresses the issue of missing rate limiting in the API server.

### Changes
- Added `tower-governor` dependency for rate limiting.
- Configured rate limiting middleware in `run_server` with 60 requests per second and a burst of 10.
- This prevents simple DoS attacks and resource exhaustion from abuse of the embedding generation endpoint.

### Verification
- Verified that the rate limiting middleware is correctly applied.
- Ran existing tests to ensure no regressions.