### PR TITLE
fix: maintain stable file IDs on re-indexing

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -108,12 +108,22 @@ impl Database {
         let path_str = path.to_string_lossy();
         let now = Utc::now().to_rfc3339();
 
+        // Use UPSERT syntax (INSERT ... ON CONFLICT) instead of INSERT OR REPLACE
+        // This preserves the ID if the row exists, only updating fields
         self.conn.execute(
-            "INSERT OR REPLACE INTO files (path, hash, indexed_at) VALUES (?, ?, ?)",
+            "INSERT INTO files (path, hash, indexed_at) VALUES (?, ?, ?)
+             ON CONFLICT(path) DO UPDATE SET
+             hash = excluded.hash,
+             indexed_at = excluded.indexed_at",
             params![path_str.as_ref(), hash, now],
         )?;
 
-        Ok(self.conn.last_insert_rowid())
+        // If updated, last_insert_rowid might not point to the updated row in older sqlite versions
+        // or depending on driver behavior, so let's fetch the ID explicitly to be safe
+        let mut stmt = self.conn.prepare("SELECT id FROM files WHERE path = ?")?;
+        let id: i64 = stmt.query_row([path_str.as_ref()], |row| row.get(0))?;
+
+        Ok(id)
     }
 
     pub fn delete_file(&self, file_id: i64) -> Result<()> {


### PR DESCRIPTION
### Description
This PR addresses an issue where file IDs were changing upon re-indexing, breaking data integrity. The issue was caused by the use of `INSERT OR REPLACE`, which deletes the existing row and creates a new one with a new auto-incremented ID.

### Changes
- Replaced `INSERT OR REPLACE` with `INSERT ... ON CONFLICT(path) DO UPDATE SET ...` (UPSERT) in `insert_file()`.
- This ensures that if a file with the same path already exists, its ID is preserved while updating its hash and indexed timestamp.
- Explicitly fetching the ID after upsert to ensure correctness across SQLite versions/drivers.

### Validation
- Verified with a reproduction test case that file IDs remain constant after re-inserting the same file with a different hash.
- Ran existing tests to ensure no regressions.