### PR TITLE
fix: enforce minimum debounce of 10ms to prevent CPU exhaustion

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -384,6 +384,9 @@ impl Config {
     }
 
     pub fn set_watch_debounce(&mut self, ms: u64) -> Result<()> {
+        if ms < 10 {
+            anyhow::bail!("Watch debounce must be at least 10ms");
+        }
         self.watch_debounce_ms = ms;
         self.save()
     }


### PR DESCRIPTION
### Description
This PR addresses an issue where setting `watch_debounce_ms` to 0 caused 100% CPU usage due to a tight polling loop. A minimum debounce value of 10ms is now enforced to prevent this denial of service condition.

### Fix
- Added validation in `set_watch_debounce` in `src/config.rs` to reject values less than 10ms.
- Setting 0 now returns a clear error message instead of causing high CPU usage.

### Testing
- Validated that `vgrep config set watch-debounce 0` now fails with "Watch debounce must be at least 10ms".
- Ran existing tests to ensure no regressions.
